### PR TITLE
call "$0" instead of hardcoded script name

### DIFF
--- a/bin/dps.sh
+++ b/bin/dps.sh
@@ -11,7 +11,7 @@ fi
 myPARAM="$1"
 if [[ $myPARAM =~ ^([1-9]|[1-9][0-9]|[1-9][0-9][0-9])$ ]];
   then
-    watch --color -n $myPARAM "dps.sh"
+    watch --color -n $myPARAM "$0"
     exit
 fi
 


### PR DESCRIPTION
Very minor change. Allows the `dps.sh` script to work when called from another directory or if the script name changes.